### PR TITLE
Adds phpunit test structure and Travis build matrix (phpunit/phpcs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+composer.lock
+
 # CakePHP 3
 
 /vendor/*
@@ -23,3 +25,5 @@
 /app/Config/core.php
 /app/Config/database.php
 /vendors/*
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+
+sudo: false
+
+env:
+  global:
+    - PHPUNIT=1
+
+matrix:
+  fast_finish: true
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 PHPUNIT=0
+
+  allow_failures:
+
+before_script:
+  - composer self-update
+  - composer install --prefer-dist --no-interaction
+
+  - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"
+
+  - phpenv rehash
+  - set +H
+  - cp phpunit.xml.dist phpunit.xml
+
+script:
+  - sh -c "if [ '$PHPUNIT' = '1' ]; then vendor/bin/phpunit; fi"
+
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+
+notifications:
+  email: false

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "A CakePHP (3.3.x) plugin for activate cors domain in your application",
     "type": "cakephp-plugin",
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.6",
         "cakephp/cakephp": ">=3.3.2 <4.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "5.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -4,14 +4,16 @@ namespace Cors\Controller;
 use App\Controller\ErrorController as BaseErrorController;
 use Cake\Event\Event;
 
-class ErrorController extends BaseErrorController {
+class ErrorController extends BaseErrorController
+{
 
     /**
      * Initialization hook method.
      *
      * @return void
      */
-    public function initialize() {
+    public function initialize()
+    {
         parent::initialize();
         $this->loadComponent('RequestHandler');
     }
@@ -22,7 +24,8 @@ class ErrorController extends BaseErrorController {
      * @param \Cake\Event\Event $event Event.
      * @return \Cake\Network\Response|null|void
      */
-    public function beforeRender(Event $event) {
+    public function beforeRender(Event $event)
+    {
         parent::beforeRender($event);
         $this->response->header(['Access-Control-Allow-Origin' => '*']);
     }

--- a/src/Error/AppExceptionRenderer.php
+++ b/src/Error/AppExceptionRenderer.php
@@ -1,17 +1,24 @@
 <?php
 namespace Cors\Error;
 
+use Cake\Core\Configure;
 use Cake\Error\ExceptionRenderer;
-use Cake\Routing\Router;
+use Cake\Event\Event;
 use Cake\Network\Request;
 use Cake\Network\Response;
-use Cake\Event\Event;
-use Cake\Core\Configure;
+use Cake\Routing\Router;
 use Exception;
 
-class AppExceptionRenderer extends ExceptionRenderer {
+class AppExceptionRenderer extends ExceptionRenderer
+{
 
-    protected function _getController() {
+    /**
+     * Returns the current controller.
+     *
+     * @return \Cake\Controller\Controller
+     */
+    protected function _getController()
+    {
         if (!$request = Router::getRequest(true)) {
             $request = Request::createFromGlobals();
         }

--- a/src/Routing/Middleware/CorsMiddleware.php
+++ b/src/Routing/Middleware/CorsMiddleware.php
@@ -1,12 +1,16 @@
 <?php
 namespace Cors\Routing\Middleware;
 
+use Cake\Core\Configure;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Cake\Core\Configure;
 
-class CorsMiddleware {
+class CorsMiddleware
+{
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $next) {
 
         if ($request->getHeader('Origin')) {
@@ -28,6 +32,9 @@ class CorsMiddleware {
         return $next($request, $response);
     }
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     private function _allowOrigin($request) {
         $allowOrigin = Configure::read('Cors.AllowOrigin');
         $origin = $request->getHeader('Origin');
@@ -48,17 +55,26 @@ class CorsMiddleware {
             return '';
         }
 
-        return (string) $allowOrigin;
+        return (string)$allowOrigin;
     }
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     private function _allowCredentials() {
         return (Configure::read('Cors.AllowCredentials')) ? 'true' : 'false';
     }
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     private function _allowMethods() {
         return implode(', ', (array) Configure::read('Cors.AllowMethods'));
     }
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     private function _allowHeaders($request) {
         $allowHeaders = Configure::read('Cors.AllowHeaders');
 
@@ -69,6 +85,9 @@ class CorsMiddleware {
         return implode(', ', (array) $allowHeaders);
     }
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     private function _exposeHeaders() {
         $exposeHeaders = Configure::read('Cors.ExposeHeaders');
 
@@ -79,8 +98,12 @@ class CorsMiddleware {
         return '';
     }
 
+    /**
+     * PHPCS docblock fix needed!
+     */
     private function _maxAge() {
         $maxAge = (string) Configure::read('Cors.MaxAge');
+
         return ($maxAge) ?: '0';
     }
 }

--- a/tests/TestCase/Controller/ErrorControllerTest.php
+++ b/tests/TestCase/Controller/ErrorControllerTest.php
@@ -1,0 +1,12 @@
+<?php
+namespace Cors\TestCase\Controller;
+
+use PHPUnit\Framework\TestCase;
+
+class ErrorControllerTest extends TestCase
+{
+    public function testPlaceholder()
+    {
+        $this->markTestIncomplete('This repo could do with some tests');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+use Cake\Core\Plugin;
+
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new Exception('Cannot find the root of the application, unable to run tests');
+};
+$root = $findRoot(__FILE__);
+unset($findRoot);
+chdir($root);
+require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
+
+Plugin::load('Cors', ['path' => dirname(dirname(__FILE__)) . DS]);


### PR DESCRIPTION
This PR:

- adds the basis for adding tests
- adds the Travis matrix for running both phpunit and [phpcs](https://github.com/cakephp/cakephp-codesniffer) when PRs are submitted

You will need to do two things:

1. enable Travis for this repo (if you have not already done that)
2. fix the remaining phpcs errors by adding correct docblocks in `CorsMiddleWare.php` (I just added `* PHPCS docblock fix needed!`)


