### PR TITLE
#10 - fixed options 404

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 use Cake\Event\EventManager;
 use Cake\Core\Configure;
+use Cake\Routing\Middleware\RoutingMiddleware;
 use Cors\Routing\Middleware\CorsMiddleware;
 
 /**
@@ -24,6 +25,6 @@ if ($config['exceptionRenderer']) {
  */
 EventManager::instance()->on('Server.buildMiddleware',
     function ($event, $middleware) {
-        $middleware->add(new CorsMiddleware());
+        $middleware->insertBefore(RoutingMiddleware::class, new CorsMiddleware());
     }
 );


### PR DESCRIPTION
Insert middleware before RoutingMiddleware to fix options request return 404 when missing $routes->fallbacks() in routes.php